### PR TITLE
[api] quick fix of endpoint response fields

### DIFF
--- a/skyagi-web/src/routes/api/get-agent/+server.ts
+++ b/skyagi-web/src/routes/api/get-agent/+server.ts
@@ -20,7 +20,7 @@ export const PUT = (async ({ request, locals }: { request: Request; locals: App.
         .single();
 
     if (checkValidity(agent)) {
-        return new Response(JSON.stringify({ 'success': 1, data: agent }), { status: 200 });
+        return new Response(JSON.stringify({ 'success': 1, agent: agent }), { status: 200 });
     } else {
         console.error(`Fail to find agent: ${error?.message}`);
         return new Response(JSON.stringify({ 'success': 0, 'error': 'agent not found' }), { status: 200 });

--- a/skyagi-web/src/routes/api/get-conversation/+server.ts
+++ b/skyagi-web/src/routes/api/get-conversation/+server.ts
@@ -33,7 +33,7 @@ export const PUT = (async ({ request, locals }: { request: Request; locals: App.
 	// a converation could have empty messages, so no need to check if messages is empty
 
     let resp = {
-        'summary': 1,
+        'success': 1,
         'name': conversation[0].name,
         'agent_ids': conversation[0].agents,
         'user_agent_ids': conversation[0].user_agents,

--- a/skyagi-web/src/routes/api/get-conversations/+server.ts
+++ b/skyagi-web/src/routes/api/get-conversations/+server.ts
@@ -22,7 +22,7 @@ export const PUT = (async ({ request, locals }: { request: Request; locals: App.
         .eq('user_id', user_id);
         
     if (checkValidity(conversations) === false) {
-        return new Response(JSON.stringify({ 'success': 0, 'error': 'conversations not found' }), { status: 200 });
+        return new Response(JSON.stringify({ 'success': 1, 'conversations': [] }), { status: 200 });
     }
     
     let res_conversations = [];


### PR DESCRIPTION
* get-agent: replace "data" with "agent"
* get-conversation: replace "summary" with "success"
* get-conversations: support returning empty conversations