### PR TITLE
[web] add ModelZ provider template

### DIFF
--- a/skyagi-web/package-lock.json
+++ b/skyagi-web/package-lock.json
@@ -14,7 +14,7 @@
 				"@supabase/supabase-js": "^2.21.0",
 				"@sveltejs/adapter-vercel": "^2.4.3",
 				"@vercel/analytics": "^1.0.0",
-				"langchain": "^0.0.84",
+				"langchain": "^0.0.96",
 				"web-vitals": "^3.3.1"
 			},
 			"devDependencies": {
@@ -1469,6 +1469,11 @@
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
 		},
+		"node_modules/@types/uuid": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+			"integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+		},
 		"node_modules/@types/websocket": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
@@ -2062,6 +2067,17 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2327,6 +2343,17 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/deep-eql": {
@@ -3407,9 +3434,9 @@
 			}
 		},
 		"node_modules/js-tiktoken": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.6.tgz",
-			"integrity": "sha512-lxHntEupgjWvSh37WxpAW4XN6UBXBtFJOpZZq5HN5oNjDfN7L/iJhHOKjyL/DFtuYXUwn5jfTciLtOWpgQmHjQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.7.tgz",
+			"integrity": "sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==",
 			"dependencies": {
 				"base64-js": "^1.5.1"
 			}
@@ -3467,20 +3494,23 @@
 			"dev": true
 		},
 		"node_modules/langchain": {
-			"version": "0.0.84",
-			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.0.84.tgz",
-			"integrity": "sha512-7b7CIwHE1vB973wRRC0GmU9Jj2bt/xN5SA17VeoHa6zuNunawC2wFUfjQzNtSw+RHtMX0VHUjoBOqQCKGktbXQ==",
+			"version": "0.0.96",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.0.96.tgz",
+			"integrity": "sha512-m1d0IWjwZK+D19uBfgmfp5sUTxJXcjJb/YuIyn2cGNmXGqOH2r2cl0TUnhuFKxTXpMTXgTywd7MYF5U5/qkNTQ==",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.4.3",
 				"ansi-styles": "^5.0.0",
 				"binary-extensions": "^2.2.0",
+				"camelcase": "6",
+				"decamelize": "5",
 				"expr-eval": "^2.0.2",
 				"flat": "^5.0.2",
-				"js-tiktoken": "^1.0.6",
+				"js-tiktoken": "^1.0.7",
 				"jsonpointer": "^5.0.1",
+				"langchainplus-sdk": "^0.0.11",
 				"ml-distance": "^4.0.0",
 				"object-hash": "^3.0.0",
-				"openai": "^3.2.0",
+				"openai": "^3.3.0",
 				"p-queue": "^6.6.2",
 				"p-retry": "4",
 				"uuid": "^9.0.0",
@@ -3498,10 +3528,14 @@
 				"@aws-sdk/client-sagemaker-runtime": "^3.310.0",
 				"@clickhouse/client": "^0.0.14",
 				"@getmetal/metal-sdk": "*",
+				"@getzep/zep-js": "^0.3.1",
+				"@gomomento/sdk": "^1.23.0",
+				"@google-cloud/storage": "^6.10.1",
 				"@huggingface/inference": "^1.5.1",
 				"@opensearch-project/opensearch": "*",
 				"@pinecone-database/pinecone": "*",
 				"@qdrant/js-client-rest": "^1.2.0",
+				"@supabase/postgrest-js": "^1.1.1",
 				"@supabase/supabase-js": "^2.10.0",
 				"@tensorflow-models/universal-sentence-encoder": "*",
 				"@tensorflow/tfjs-converter": "*",
@@ -3512,19 +3546,21 @@
 				"apify-client": "^2.7.1",
 				"axios": "*",
 				"cheerio": "^1.0.0-rc.12",
-				"chromadb": "^1.4.2",
+				"chromadb": "^1.5.2",
 				"cohere-ai": "^5.0.2",
 				"d3-dsv": "^2.0.0",
 				"epub2": "^3.0.1",
-				"faiss-node": "^0.2.0",
+				"faiss-node": "^0.2.1",
 				"google-auth-library": "^8.8.0",
 				"hnswlib-node": "^1.4.2",
 				"html-to-text": "^9.0.5",
 				"ignore": "^5.2.0",
 				"mammoth": "*",
-				"meriyah": "*",
 				"mongodb": "^5.2.0",
+				"mysql2": "^3.3.3",
 				"pdf-parse": "1.1.1",
+				"peggy": "^3.0.2",
+				"pg": "^8.11.0",
 				"pickleparser": "^0.1.0",
 				"playwright": "^1.32.1",
 				"puppeteer": "^19.7.2",
@@ -3532,6 +3568,7 @@
 				"replicate": "^0.9.0",
 				"srt-parser-2": "^1.2.2",
 				"typeorm": "^0.3.12",
+				"typesense": "^1.5.3",
 				"weaviate-ts-client": "^1.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -3553,6 +3590,15 @@
 				"@getmetal/metal-sdk": {
 					"optional": true
 				},
+				"@getzep/zep-js": {
+					"optional": true
+				},
+				"@gomomento/sdk": {
+					"optional": true
+				},
+				"@google-cloud/storage": {
+					"optional": true
+				},
 				"@huggingface/inference": {
 					"optional": true
 				},
@@ -3563,6 +3609,9 @@
 					"optional": true
 				},
 				"@qdrant/js-client-rest": {
+					"optional": true
+				},
+				"@supabase/postgrest-js": {
 					"optional": true
 				},
 				"@supabase/supabase-js": {
@@ -3625,13 +3674,19 @@
 				"mammoth": {
 					"optional": true
 				},
-				"meriyah": {
-					"optional": true
-				},
 				"mongodb": {
 					"optional": true
 				},
+				"mysql2": {
+					"optional": true
+				},
 				"pdf-parse": {
+					"optional": true
+				},
+				"peggy": {
+					"optional": true
+				},
+				"pg": {
 					"optional": true
 				},
 				"pickleparser": {
@@ -3655,6 +3710,9 @@
 				"typeorm": {
 					"optional": true
 				},
+				"typesense": {
+					"optional": true
+				},
 				"weaviate-ts-client": {
 					"optional": true
 				}
@@ -3669,6 +3727,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/langchainplus-sdk": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/langchainplus-sdk/-/langchainplus-sdk-0.0.11.tgz",
+			"integrity": "sha512-bEovYVJZq88LYznDfK+ohNVd0lqQ1DMgE/A/8ZkqsiyaRuEjvIQj4PLc0VQ8htWPBljrfTu8oS7g+SGWYTZfNw==",
+			"dependencies": {
+				"@types/uuid": "^9.0.1",
+				"commander": "^10.0.1",
+				"p-queue": "^6.6.2",
+				"p-retry": "4",
+				"uuid": "^9.0.0"
+			},
+			"bin": {
+				"langchain": "dist/cli/main.cjs"
+			}
+		},
+		"node_modules/langchainplus-sdk/node_modules/commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/levn": {
@@ -4149,9 +4230,9 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
-			"integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+			"integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
 			"dependencies": {
 				"axios": "^0.26.0",
 				"form-data": "^4.0.0"
@@ -4774,9 +4855,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -7020,6 +7101,11 @@
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
 		},
+		"@types/uuid": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+			"integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+		},
 		"@types/websocket": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
@@ -7408,6 +7494,11 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
+		"camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+		},
 		"camelcase-css": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -7589,6 +7680,11 @@
 			"requires": {
 				"ms": "2.1.2"
 			}
+		},
+		"decamelize": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
 		},
 		"deep-eql": {
 			"version": "4.1.3",
@@ -8394,9 +8490,9 @@
 			"dev": true
 		},
 		"js-tiktoken": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.6.tgz",
-			"integrity": "sha512-lxHntEupgjWvSh37WxpAW4XN6UBXBtFJOpZZq5HN5oNjDfN7L/iJhHOKjyL/DFtuYXUwn5jfTciLtOWpgQmHjQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.7.tgz",
+			"integrity": "sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==",
 			"requires": {
 				"base64-js": "^1.5.1"
 			}
@@ -8445,20 +8541,23 @@
 			"dev": true
 		},
 		"langchain": {
-			"version": "0.0.84",
-			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.0.84.tgz",
-			"integrity": "sha512-7b7CIwHE1vB973wRRC0GmU9Jj2bt/xN5SA17VeoHa6zuNunawC2wFUfjQzNtSw+RHtMX0VHUjoBOqQCKGktbXQ==",
+			"version": "0.0.96",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.0.96.tgz",
+			"integrity": "sha512-m1d0IWjwZK+D19uBfgmfp5sUTxJXcjJb/YuIyn2cGNmXGqOH2r2cl0TUnhuFKxTXpMTXgTywd7MYF5U5/qkNTQ==",
 			"requires": {
 				"@anthropic-ai/sdk": "^0.4.3",
 				"ansi-styles": "^5.0.0",
 				"binary-extensions": "^2.2.0",
+				"camelcase": "6",
+				"decamelize": "5",
 				"expr-eval": "^2.0.2",
 				"flat": "^5.0.2",
-				"js-tiktoken": "^1.0.6",
+				"js-tiktoken": "^1.0.7",
 				"jsonpointer": "^5.0.1",
+				"langchainplus-sdk": "^0.0.11",
 				"ml-distance": "^4.0.0",
 				"object-hash": "^3.0.0",
-				"openai": "^3.2.0",
+				"openai": "^3.3.0",
 				"p-queue": "^6.6.2",
 				"p-retry": "4",
 				"uuid": "^9.0.0",
@@ -8471,6 +8570,25 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+				}
+			}
+		},
+		"langchainplus-sdk": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/langchainplus-sdk/-/langchainplus-sdk-0.0.11.tgz",
+			"integrity": "sha512-bEovYVJZq88LYznDfK+ohNVd0lqQ1DMgE/A/8ZkqsiyaRuEjvIQj4PLc0VQ8htWPBljrfTu8oS7g+SGWYTZfNw==",
+			"requires": {
+				"@types/uuid": "^9.0.1",
+				"commander": "^10.0.1",
+				"p-queue": "^6.6.2",
+				"p-retry": "4",
+				"uuid": "^9.0.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+					"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
 				}
 			}
 		},
@@ -8820,9 +8938,9 @@
 			}
 		},
 		"openai": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
-			"integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+			"integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
 			"requires": {
 				"axios": "^0.26.0",
 				"form-data": "^4.0.0"
@@ -9199,9 +9317,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}

--- a/skyagi-web/package.json
+++ b/skyagi-web/package.json
@@ -50,7 +50,7 @@
 		"@supabase/supabase-js": "^2.21.0",
 		"@sveltejs/adapter-vercel": "^2.4.3",
 		"@vercel/analytics": "^1.0.0",
-		"langchain": "^0.0.84",
+		"langchain": "^0.0.96",
 		"web-vitals": "^3.3.1"
 	}
 }

--- a/skyagi-web/src/lib/model/model.ts
+++ b/skyagi-web/src/lib/model/model.ts
@@ -21,8 +21,6 @@ export interface LLMSettings {
     provider: ModelProvider;
     name: string;
     args: { [k: string]: unknown };
-    credentials: { [k: string]: unknown };
-    configuration?: { [k: string]: unknown };
 }
 
 export interface EmbeddingSettings {
@@ -30,8 +28,6 @@ export interface EmbeddingSettings {
     provider: ModelProvider;
     name: string;
     args: { [k: string]: unknown };
-    credentials: { [k: string]: unknown };
-    configuration?: { [k: string]: unknown };
     embeddingSize: number;
 }
 
@@ -70,13 +66,11 @@ export const providerTemplates: {
                     type: LLMType.ChatOpenAI,
                     provider: ModelProvider.OpenAI,
                     name: 'openai-gpt-3.5-turbo',
-                    credentials: {
-                        // NOTE: This should be given by user
-                        openAIApiKey: ""
-                    },
                     args: {
                         modelName: 'gpt-3.5-turbo',
-                        maxTokens: 1500
+                        maxTokens: 1500,
+                        // NOTE: This should be given by user
+                        openAIApiKey: ""
                     }
                 },
                 {
@@ -84,26 +78,22 @@ export const providerTemplates: {
                     type: LLMType.ChatOpenAI,
                     provider: ModelProvider.OpenAI,
                     name: 'openai-gpt-4',
-                    credentials: {
-                        // NOTE: This should be given by user
-                        openAIApiKey: ""
-                    },
                     args: {
                         modelName: 'gpt-4',
-                        maxTokens: 1500
+                        maxTokens: 1500,
+                        // NOTE: This should be given by user
+                        openAIApiKey: ""
                     }
                 },
                 {
                     type: LLMType.OpenAI,
                     provider: ModelProvider.OpenAI,
                     name: 'openai-text-davinci-003',
-                    credentials: {
-                        // NOTE: This should be given by user
-                        openAIApiKey: ""
-                    },
                     args: {
                         modelName: 'text-davinci-003',
-                        maxTokens: 1500
+                        maxTokens: 1500,
+                        // NOTE: This should be given by user
+                        openAIApiKey: ""
                     }
                 }
             ],
@@ -112,12 +102,10 @@ export const providerTemplates: {
                     type: EmbeddingType.OpenAIEmbeddings,
                     provider: ModelProvider.OpenAI,
                     name: 'openai-text-embedding-ada-002',
-                    credentials: {
+                    args: {
+                        modelName: 'text-embedding-ada-002',
                         // NOTE: This should be given by user
                         openAIApiKey: ""
-                    },
-                    args: {
-                        modelName: 'text-embedding-ada-002'
                     },
                     embeddingSize: 1536
                 }
@@ -135,16 +123,14 @@ export const providerTemplates: {
                     type: LLMType.ChatOpenAI,
                     provider: ModelProvider.ModelZ,
                     name: 'modelz-host-model',
-                    credentials: {
-                        // NOTE: This should be given by user
-                        openAIApiKey: ""
-                    },
                     args: {
-                        maxTokens: 1500
-                    },
-                    configuration: {
+                        maxTokens: 1500,
                         // NOTE: This should be given by user
-                        basePath: ""
+                        openAIApiKey: "",
+                        configuration: {
+                            // NOTE: This should be given by user
+                            basePath: ""
+                        }
                     }
                 }
             ]
@@ -159,7 +145,7 @@ export function load_llm_from_config(config: LLMSettings) {
     }
 
     const cls = llm_type_to_cls_dict[config_type];
-    return new cls(config.args, config.configuration);
+    return new cls(config.args);
 }
 
 export function load_embedding_from_config(config: EmbeddingSettings) {
@@ -192,28 +178,4 @@ export function get_all_embeddings(): string[] {
         }
     }
     return all_embeddings;
-}
-
-// Get corresponding LLM's credentials fields
-export function get_llm_credentials_fields(modelName: string): string[] {
-    for (const [provider, template] of Object.entries(providerTemplates)) {
-        for (const llm of (template.models.llms || [])) {
-            if (modelName === llm.name) {
-                return Object.keys(llm.credentials);
-            }
-        }
-    }
-    return [];
-}
-
-// Get corresponding Embedding's credentials fields
-export function get_embedding_credentials_fields(modelName: string): string[] {
-    for (const [provider, template] of Object.entries(providerTemplates)) {
-        for (const embedding of (template.models.embeddings || [])) {
-            if (modelName === embedding.name) {
-                return Object.keys(embedding.credentials);
-            }
-        }
-    }
-    return [];
 }

--- a/skyagi-web/src/lib/settings/credentials.ts
+++ b/skyagi-web/src/lib/settings/credentials.ts
@@ -1,7 +1,0 @@
-import { ModelProvider } from "$lib/model/model";
-
-export const providerToCredentials = {
-    [ModelProvider.OpenAI]: {
-        openAIApiKey: undefined
-    }
-}


### PR DESCRIPTION
1. Bump up langchain version to set OpenAPI LLM/ChatModel `configuration` within its constructor first argument `fields`.
2. Create a ModelZ provider template, it is not toggled on yet until the frontend UI will be able to collect and stored required fields from user.
3. Refactor `credentials` field into `args`, remove useless credentials related utils.